### PR TITLE
Adding the functionality of user bots

### DIFF
--- a/sweetiebot/sweetiebot.go
+++ b/sweetiebot/sweetiebot.go
@@ -519,14 +519,21 @@ func (w *MiscModule) Description() string {
 	return "A collection of miscellaneous commands that don't belong to a module."
 }
 
-func AttachToGuild(g *discordgo.Guild) {
-	guild, exists := sb.guilds[SBatoi(g.ID)]
-	for _, testguild := range SweetieBot.guilds {
+func IsInitiated(g *discordgo.Guild) bool {
+	for _, testguild := range sb.guilds {
 		if g.ID == testguild.Guild.ID {
 			if testguild.InitSB == true {
-				return
+				return true
 			}
 		}
+	}
+	return false
+}
+
+func AttachToGuild(g *discordgo.Guild) {
+	guild, exists := sb.guilds[SBatoi(g.ID)]
+	if IsInitiated(g) == true {
+		return
 	}
 	if sb.Debug {
 		_, ok := sb.DebugChannels[g.ID]
@@ -1314,7 +1321,13 @@ func Initialize(Token string) {
 	}
 
 	sb.db = db
-	sb.dg, err = discordgo.New("Bot " + Token)
+	isuser, _ := ioutil.ReadFile("isuser")
+	if isuser == nil {
+		sb.dg, err = discordgo.New("Bot " + Token)
+	} else {
+		sb.dg, err = discordgo.New(Token)
+		fmt.Println("Started SweetieBot on a user account.")
+	}
 	if err != nil {
 		fmt.Println("Error creating discord session", err.Error())
 		return

--- a/sweetiebot/sweetiebot.go
+++ b/sweetiebot/sweetiebot.go
@@ -186,6 +186,7 @@ type GuildInfo struct {
 	hooks        ModuleHooks
 	modules      []Module
 	commands     map[string]Command
+	InitSB       bool
 }
 
 type Version struct {
@@ -486,6 +487,11 @@ func SBReady(s *discordgo.Session, r *discordgo.Ready) {
 	fmt.Println("Ready message receieved, waiting for guilds...")
 	sb.SelfID = r.User.ID
 	sb.SelfAvatar = r.User.Avatar
+	if r.Guilds != nil {
+		for _, G := range r.Guilds {
+			AttachToGuild(G)
+		}
+	}
 
 	// Only used to change sweetiebot's name or avatar
 	//ChangeBotName(s, "Sweetie", "avatar.jpg")
@@ -515,6 +521,13 @@ func (w *MiscModule) Description() string {
 
 func AttachToGuild(g *discordgo.Guild) {
 	guild, exists := sb.guilds[SBatoi(g.ID)]
+	for _, testguild := range SweetieBot.guilds {
+		if g.ID == testguild.Guild.ID {
+			if testguild.InitSB == true {
+				return
+			}
+		}
+	}
 	if sb.Debug {
 		_, ok := sb.DebugChannels[g.ID]
 		if !ok {

--- a/sweetiebot/sweetiebot.go
+++ b/sweetiebot/sweetiebot.go
@@ -533,6 +533,7 @@ func IsInitiated(g *discordgo.Guild) bool {
 func AttachToGuild(g *discordgo.Guild) {
 	guild, exists := sb.guilds[SBatoi(g.ID)]
 	if IsInitiated(g) == true {
+		fmt.Println("Guild " + g.Name + " called, already loaded.")
 		return
 	}
 	if sb.Debug {


### PR DESCRIPTION
Adding a simple functionality of potential user bots, managing this is tricky, but more and more servers want and need these "new" kind of bots, i saw that this could be easily integrated in sweetiebot, by adding a few lines.

If loaded on a normal bot account, this change should have no effects.

This change is needed for discord to receive and handle on the MESSAGE_CREATE user endpoint without an error, else, discord will return this error with any other POST request.