### PR TITLE
Minor timestamp changes

### DIFF
--- a/sweetiebot/db.go
+++ b/sweetiebot/db.go
@@ -365,7 +365,7 @@ func (db *BotDB) GetMember(id uint64, guild uint64) (*discordgo.Member, time.Tim
 	var discriminator int
 	err := db.sqlGetMember.QueryRow(id, guild).Scan(&m.User.ID, &m.User.Username, &discriminator, &lastseen, &m.Nick, &joinedat, &firstmessage)
 	if !joinedat.IsZero() {
-		m.JoinedAt = discordgo.Timestamp(joinedat.Format(time.RFC3339))
+		m.JoinedAt = string(discordgo.Timestamp(joinedat.Format(time.RFC3339)))
 	}
 	if discriminator > 0 {
 		m.User.Discriminator = strconv.Itoa(discriminator)

--- a/sweetiebot/util.go
+++ b/sweetiebot/util.go
@@ -395,7 +395,7 @@ func GetTimestamp(m *discordgo.Message) time.Time {
 
 // GetJoinedAt returns either the time the member joined or time.Now() if there is an error
 func GetJoinedAt(m *discordgo.Member) time.Time {
-	if t, err := m.JoinedAt.Parse(); err == nil {
+	if t, err := discordgo.Timestamp(m.JoinedAt).Parse(); err == nil {
 		return t
 	}
 	return time.Now().UTC()

--- a/usersmodule/UsersModule.go
+++ b/usersmodule/UsersModule.go
@@ -484,7 +484,7 @@ func (c *userInfoCommand) Process(args []string, msg *discordgo.Message, indices
 		m.JoinedAt = dbmember.JoinedAt
 	}
 	authortz := info.GetTimezone(bot.DiscordUser(msg.Author.ID))
-	joinedat, err := m.JoinedAt.Parse()
+	joinedat, err := discordgo.Timestamp(m.JoinedAt).Parse()
 	joined := ""
 	if err == nil {
 		joined = bot.TimeDiff(timestamp.Sub(joinedat.In(authortz))) + " ago (" + joinedat.In(authortz).Format(time.RFC822) + ")"


### PR DESCRIPTION
Hi, those would crash on my `go version go1.10.4 linux/386` with the latest discordgo version, with the following:

```
../sweetiebot/db.go:368:14: cannot use discordgo.Timestamp(joinedat.Format(time.RFC3339)) (type discordgo.Timestamp) as type string in assignment
../sweetiebot/util.go:398:25: m.JoinedAt.Parse undefined (type string has no field or method Parse)
```

This PR fixes it. Check that it works with your versioning 